### PR TITLE
Upgrade projects and update packages

### DIFF
--- a/src/Learning.Grpc.Client.ConsoleHost/Learning.Grpc.Client.ConsoleHost.csproj
+++ b/src/Learning.Grpc.Client.ConsoleHost/Learning.Grpc.Client.ConsoleHost.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc" Version="1.16.0" />
+    <PackageReference Include="Grpc" Version="2.46.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Learning.Grpc.Server.ConsoleHost/Learning.Grpc.Server.ConsoleHost.csproj
+++ b/src/Learning.Grpc.Server.ConsoleHost/Learning.Grpc.Server.ConsoleHost.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <StartupObject></StartupObject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc" Version="1.16.0" />
+    <PackageReference Include="Grpc" Version="2.46.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Learning.Grpc.sln
+++ b/src/Learning.Grpc.sln
@@ -1,13 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.136
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32901.215
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Learning.Grpc.Server.ConsoleHost", "Learning.Grpc.Server.ConsoleHost\Learning.Grpc.Server.ConsoleHost.csproj", "{E25FD466-BB47-4B22-BCB0-EA90DF42A30D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Learning.Grpc.Server.ConsoleHost", "Learning.Grpc.Server.ConsoleHost\Learning.Grpc.Server.ConsoleHost.csproj", "{E25FD466-BB47-4B22-BCB0-EA90DF42A30D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Learning.Grpc.Client.ConsoleHost", "Learning.Grpc.Client.ConsoleHost\Learning.Grpc.Client.ConsoleHost.csproj", "{D736ED73-939B-45BB-8848-4F84ACFABDF3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Learning.Grpc.Client.ConsoleHost", "Learning.Grpc.Client.ConsoleHost\Learning.Grpc.Client.ConsoleHost.csproj", "{D736ED73-939B-45BB-8848-4F84ACFABDF3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Learning.Grpc", "Learning.Grpc\Learning.Grpc.csproj", "{7001328D-A587-478F-9460-561D3A24CEF0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Learning.Grpc", "Learning.Grpc\Learning.Grpc.csproj", "{7001328D-A587-478F-9460-561D3A24CEF0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Learning.Grpc/Learning.Grpc.csproj
+++ b/src/Learning.Grpc/Learning.Grpc.csproj
@@ -1,14 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.6.1" />
-    <PackageReference Include="Google.Protobuf.Tools" Version="3.6.1" />
-    <PackageReference Include="Grpc" Version="1.16.0" />
-    <PackageReference Include="Grpc.Tools" Version="1.16.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.21.6" />
+    <PackageReference Include="Google.Protobuf.Tools" Version="3.21.6" />
+    <PackageReference Include="Grpc" Version="2.46.3" />
+    <PackageReference Include="Grpc.Tools" Version="2.48.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Upgrades projects to .NET 6 and updates NuGet packages to the latest versions.

Besides modernizing, this addresses a security vulnerability in the Google.Protobuf package.